### PR TITLE
Updated GSL orographic drag suite to enable use of custom orographic …

### DIFF
--- a/tests/fv3_conf/ccpp_gsd_run_drag_suite.IN
+++ b/tests/fv3_conf/ccpp_gsd_run_drag_suite.IN
@@ -1,0 +1,87 @@
+rm -fr INPUT RESTART
+mkdir INPUT RESTART
+if [ $WARM_START = .F. ]; then
+  cp -r @[RTPWD]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/* INPUT/
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile1/oro.tile1.nc ./INPUT/oro_data_ls.tile1.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile2/oro.tile2.nc ./INPUT/oro_data_ls.tile2.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile3/oro.tile3.nc ./INPUT/oro_data_ls.tile3.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile4/oro.tile4.nc ./INPUT/oro_data_ls.tile4.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile5/oro.tile5.nc ./INPUT/oro_data_ls.tile5.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile6/oro.tile6.nc ./INPUT/oro_data_ls.tile6.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile1/oro.ss.tile1.nc ./INPUT/oro_data_ss.tile1.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile2/oro.ss.tile2.nc ./INPUT/oro_data_ss.tile2.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile3/oro.ss.tile3.nc ./INPUT/oro_data_ss.tile3.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile4/oro.ss.tile4.nc ./INPUT/oro_data_ss.tile4.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile5/oro.ss.tile5.nc ./INPUT/oro_data_ss.tile5.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile6/oro.ss.tile6.nc ./INPUT/oro_data_ss.tile6.nc
+else
+  cp -r @[RTPWD]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/grid_spec*.nc INPUT/
+  cp -r @[RTPWD]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/C96_grid*.nc INPUT/
+  cp -r @[RTPWD]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/oro_data*.nc INPUT/
+  cp ../fv3_ccpp_gsd_coldstart${RT_SUFFIX}/RESTART/* INPUT/
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile1/oro.tile1.nc ./INPUT/oro_data_ls.tile1.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile2/oro.tile2.nc ./INPUT/oro_data_ls.tile2.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile3/oro.tile3.nc ./INPUT/oro_data_ls.tile3.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile4/oro.tile4.nc ./INPUT/oro_data_ls.tile4.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile5/oro.tile5.nc ./INPUT/oro_data_ls.tile5.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile6/oro.tile6.nc ./INPUT/oro_data_ls.tile6.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile1/oro.ss.tile1.nc ./INPUT/oro_data_ss.tile1.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile2/oro.ss.tile2.nc ./INPUT/oro_data_ss.tile2.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile3/oro.ss.tile3.nc ./INPUT/oro_data_ss.tile3.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile4/oro.ss.tile4.nc ./INPUT/oro_data_ss.tile4.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile5/oro.ss.tile5.nc ./INPUT/oro_data_ss.tile5.nc
+  ln -s /scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96/tile6/oro.ss.tile6.nc ./INPUT/oro_data_ss.tile6.nc
+fi
+
+cp    @[RTPWD]/FV3_input_data/INPUT/aerosol.dat .
+cp    @[RTPWD]/FV3_input_data/INPUT/co2historicaldata_201*.txt .
+cp    @[RTPWD]/FV3_input_data/INPUT/sfc_emissivity_idx.txt .
+cp    @[RTPWD]/FV3_input_data/INPUT/solarconstant_noaa_an.txt .
+cp    @[RTPWD]/FV3_input_data/ozprdlos_2015_new_sbuvO3_tclm15_nuchem.f77 ./global_o3prdlos.f77
+cp    @[RTPWD]/FV3_input_data/global_h2o_pltc.f77 ./global_h2oprdlos.f77
+cp    @[RTPWD]/FV3_input_data/*grb .
+cp    @[RTPWD]/FV3_input_data/*_table .
+
+# Copy diag table file depending on LSM
+if [ $LSM = 1 ]; then
+  cp  @[RTPWD]/FV3_input_data_gsd/diag_table_gsd_noah diag_table
+elif [ $LSM = 3 ]; then
+  cp  @[RTPWD]/FV3_input_data_gsd/diag_table_gsd_ruc  diag_table
+fi
+
+# Copy field table, depending on microphysics choice and whether MYNN/SATMEDMF is used
+if [ $IMP_PHYSICS = 8 ]; then
+  if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
+    cp  @[RTPWD]/FV3_input_data_gsd/field_table_gsd field_table
+  else
+    cp  @[RTPWD]/FV3_input_data_gsd/field_table_gf_thompson field_table
+  fi
+elif [ $IMP_PHYSICS = 11 ]; then
+  if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
+    cp @[RTPWD]/FV3_input_data_gsd/field_table_suite2 field_table
+  else
+    cp @[RTPWD]/FV3_input_data/field_table_gfdlmp field_table
+  fi
+else
+  echo "ERROR, no field table configured for IMP_PHYSICS=${IMP_PHYSICS}"
+  exit 1
+fi
+cp    @[RTPWD]/FV3_input_data/*configure .
+
+# Thompson MP lookup tables - copy standard and SIONlib tables of precomputed tables
+if [ $IMP_PHYSICS = 8 ]; then
+  cp    @[RTPWD]/FV3_input_data_gsd/thompson_tables_precomp.sl .
+  cp    @[RTPWD]/FV3_input_data_gsd/qr_acr_qs.dat .
+  cp    @[RTPWD]/FV3_input_data_gsd/qr_acr_qg.dat .
+  cp    @[RTPWD]/FV3_input_data_gsd/freezeH2O.dat .
+  cp    @[RTPWD]/FV3_input_data_gsd/CCN_ACTIVATE.BIN .
+fi
+
+cp ${PATHRT}/../FV3/ccpp/suites/suite_${CCPP_SUITE}.xml suite_${CCPP_SUITE}.xml
+
+# Add path to libccpp.so and libccpphys.so to LD_LIBRARY_PATH, append to module-setup.sh
+echo " " >> module-setup.sh
+echo "# Add path to libccpp.so and libccpphys.so to LD_LIBRARY_PATH"
+echo "export LD_LIBRARY_PATH=${PATHRT}/../FV3/${CCPP_LIB_DIR}:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> module-setup.sh
+echo " " >> module-setup.sh
+

--- a/tests/tests/fv3_ccpp_gsd_drag_suite
+++ b/tests/tests/fv3_ccpp_gsd_drag_suite
@@ -84,7 +84,7 @@ export DO_SAT_ADJ=.F.
 export LRADAR=.T.
 export LTAEROSOL=.T.
 
-export FV3_RUN=ccpp_gsd_run.IN
+export FV3_RUN=ccpp_gsd_run_drag_suite.IN
 export CCPP_SUITE=FV3_GSD_v0_drag_suite
 export CCPP_LIB_DIR=ccpp/lib
 export INPUT_NML=ccpp_gsd.nml.IN


### PR DESCRIPTION
This is an update of the GSL orographic drag suite to use separate "small-scale" and "large-scale" orographic drag parameters, both of which can be read in by custom created static files.

These are suggested modifications to the regression test, in which the orographic statistics files are staged to be read in at runtime.  The C96 static files are on Hera at:
/scratch2/BMC/wrfruc/mtoy/FV3GFS/GWD_static_files/C96
Feel free to copy these to the directories where the other FV3 static files live.
